### PR TITLE
 core: Report fake model name to GMS using reflection.

### DIFF
--- a/core/java/com/android/internal/os/Zygote.java
+++ b/core/java/com/android/internal/os/Zygote.java
@@ -25,6 +25,7 @@ import android.net.Credentials;
 import android.net.LocalServerSocket;
 import android.net.LocalSocket;
 import android.net.NetworkUtils;
+import android.os.Build;
 import android.os.FactoryTest;
 import android.os.IVold;
 import android.os.Process;
@@ -46,6 +47,7 @@ import java.io.DataOutputStream;
 import java.io.FileDescriptor;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.reflect.Field;
 
 /** @hide */
 public final class Zygote {
@@ -786,6 +788,34 @@ public final class Zygote {
 
     private static native void nativeBoostUsapPriority();
 
+    private static void maybeSetGmsModel(String packageName, String loggingTag) {
+        if (packageName != null &&
+            packageName.startsWith("com.google.android.gms")) {
+            /*
+             * This would be much prettier if we just removed "final" from the MODEL field in Build,
+             * but that's easy to detect should Google ever catch onto this. Inspecting bytecode
+             * is much harder so this is more future-proof.
+             *
+             * While it's an awful hack, it's technically safe because the field was populated at
+             * runtime (in pre-fork Zygote) and it's not a primitive.
+             */
+            try {
+                // Unlock
+                Field field = Build.class.getDeclaredField("MODEL");
+                field.setAccessible(true);
+
+                // Edit
+                String newModel = Build.MODEL + "\u200b";
+                field.set(null, newModel);
+
+                // Lock
+                field.setAccessible(false);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                Log.w(loggingTag, "Failed to set fake model name for GMS", e);
+            }
+        }
+    }
+
     static void setAppProcessName(ZygoteArguments args, String loggingTag) {
         if (args.mNiceName != null) {
             Process.setArgV0(args.mNiceName);
@@ -794,6 +824,9 @@ public final class Zygote {
         } else {
             Log.w(loggingTag, "Unable to set package name.");
         }
+
+        // Modify model to defy SafetyNet hardware attestation in GMS
+        maybeSetGmsModel(args.mPackageName, loggingTag);
     }
 
     private static final String USAP_ERROR_PREFIX = "Invalid command to USAP: ";


### PR DESCRIPTION
 * SafetyNet currently enforces hardware attestation for specific devices
   (mostly Pixels at the moment) by checking the product model name using
   Build.MODEL. We could alter the product model name globally, but that's
   ugly and can break apps that check the model name for features or to
   just report information to the user.

 * Instead of modifying the model name globally, detect when Google Play
   Services is launching and modify the Build.MODEL field in its post-fork
   process instead. This is done early during app start before the app's
   code starts to run. To be more stealthy, we also use reflection to edit
   the final field directly and restore the final modifier once we're done
   rather than removing final from the field declaration. This works
   because even though part of SafetyNet runs in the context of client apps
   (snet.jar), that's just a thin client — the real attestation logic takes
   place in Play Services.

 * Instead of blatantly changing the model name to a completely different
   device or dummy name, we only append an invisible U+200B ZERO-WIDTH
   SPACE character to it so the user doesn't see a weird device logged into
   their Google account. The invisible character is enough to defy
   SafetyNet and make it revert back to basic (software) attestation.

Change-Id: I09495a7aa1e59b3bd59f3dbd4c9cdd701b00df5d